### PR TITLE
Suppress precompilation warnings in Julia 1.0

### DIFF
--- a/src/Maybe.jl
+++ b/src/Maybe.jl
@@ -43,7 +43,9 @@ include("something.jl")
 include("core.jl")
 include("lift.jl")
 include("extras.jl")
-Implementations.finalize_module()
+finalize_implementations()
 end
+
+Implementations.finalize_package()
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,6 +27,10 @@ end
 
 define_liftr() = Base.eval(Maybe.Implementations, define_liftr_impl())
 
+function finalize_implementations()
+    define_liftr()
+end
+
 # See ThreadsX.jl
 function define_docstrings()
     docstrings = Pair[:Maybe=>joinpath(dirname(@__DIR__), "README.md")]
@@ -50,13 +54,12 @@ function define_docstrings()
     end
 end
 
-function finalize_module()
+function finalize_package()
     @eval Maybe begin
         const T = Implementations.MaybeType
         const $(Symbol("@something")) = Implementations.$(Symbol("@something"))
         const $(Symbol("@?")) = Implementations.$(Symbol("@?"))
         export $(Symbol("@?"))
     end
-    define_liftr()
     define_docstrings()
 end


### PR DESCRIPTION
In Julia 1.0, there are a lot of warnings like

```
WARNING: eval from module Maybe to Implementations:    
Expr(:block, #= Symbol("/home/runner/work/Maybe.jl/Maybe.jl/src/utils.jl"):55 =#, Expr(:const, :T = Expr(:., :Implementations, :(:MaybeType))), #= Symbol("/home/runner/work/Maybe.jl/Maybe.jl/src/utils.jl"):56 =#, Expr(:const, Symbol("@something") = Expr(:., :Implementations, :(Symbol("@something")))), #= Symbol("/home/runner/work/Maybe.jl/Maybe.jl/src/utils.jl"):57 =#, Expr(:const, Symbol("@?") = Expr(:., :Implementations, :(Symbol("@?")))), #= Symbol("/home/runner/work/Maybe.jl/Maybe.jl/src/utils.jl"):58 =#, Expr(:export, Symbol("@?")))
  ** incremental compilation may be broken for this module **
```

See, e.g., https://github.com/tkf/Maybe.jl/runs/886179504?check_suite_focus=true#step:5:18

This PR implements a workaround.
