### PR TITLE
Use `JULIA_PKG_SERVER` mitigation in julia-buildpkg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
+      # Use `JULIA_PKG_SERVER` mitigation implemented in julia-buildpkg:
+      - uses: julia-actions/julia-buildpkg@v1
       - run: julia -e 'using Pkg; pkg"add https://github.com/tkf/Run.jl"'
       - run: julia -e 'using Run; Run.prepare("test/environments/main")'
       - run: julia -e 'using Run; Run.test(project="test/environments/main")'


### PR DESCRIPTION
In https://github.com/tkf/Maybe.jl/pull/32/checks?check_run_id=1171555165#step:4:10 I'm seeing 

```
┌ Warning: could not download https://pkg.julialang.org/registries
└ @ Pkg.Types /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/Types.jl:951
```

and then

```
curl: (22) The requested URL returned error: 502 Bad Gateway
ERROR: could not download https://pkg.julialang.org/registry/23338594-aafe-5451-b93e-139f81909106/0bccf009fec6b1e43039d998a0be039cd9f3a195
```


## Commit Message
Use `JULIA_PKG_SERVER` mitigation in julia-buildpkg (#33)

This PR avoids failures in us-east.pkg.julialang.org by first running
`julia-buildpkg` (which uses `JULIA_PKG_SERVER=""` when initializing
the registry).