### PR TITLE
Fix precompilation error for 1.6-DEV

### DIFF
--- a/src/Maybe.jl
+++ b/src/Maybe.jl
@@ -11,6 +11,15 @@ function getproperty end
 
 function _break end
 
+"""
+    Maybe.Extras
+
+A namespace for extra API; this is for preserving `Maybe.*` namespace
+for (mainly) `Base`-compatible API.
+
+Since there is no name clash with `Base` API, `using Maybe.Extras`
+imports the API defined in `Maybe.Extras`.
+"""
 baremodule Extras
 export getnested, ifnothing, maybe, defaultto
 function maybe end

--- a/src/docs/Extras.md
+++ b/src/docs/Extras.md
@@ -1,7 +1,0 @@
-    Maybe.Extras
-
-A namespace for extra API; this is for preserving `Maybe.*` namespace
-for (mainly) `Base`-compatible API.
-
-Since there is no name clash with `Base` API, `using Maybe.Extras`
-imports the API defined in `Maybe.Extras`.


### PR DESCRIPTION
## Commit Message
Fix precompilation error for 1.6-DEV (#34)

This patch workarounds the change in Julia 1.6-DEV
https://github.com/JuliaLang/julia/issues/37771
i.e., `@doc SubModule "..."` outside `SubModule` stopped working.

This patch avoids the precompilation error by simply inlining `Extras`
docstring.