### PR TITLE
Improve line numbers for at-something

### DIFF
--- a/src/Maybe.jl
+++ b/src/Maybe.jl
@@ -53,9 +53,9 @@ if !isdefined(Base, Symbol("@var_str"))
 end
 
 include("utils.jl")
+include("lift.jl")
 include("something.jl")
 include("core.jl")
-include("lift.jl")
 include("extras.jl")
 finalize_implementations()
 end

--- a/src/lift.jl
+++ b/src/lift.jl
@@ -31,7 +31,7 @@ on_assignments(f, ex::Expr) =
         error("unsupported expression: $ex")
     end
 
-is_advancing(old) = old -> is_advancing(old, new)
+is_advancing(old) = new -> is_advancing(old, new)
 is_advancing(old, new) = old.file === new.file && old.line < new.line
 
 function update_if_advancing!(lastline::Ref{LineNumberNode}, lnn::LineNumberNode)

--- a/src/something.jl
+++ b/src/something.jl
@@ -8,6 +8,7 @@ macro something(args...)
 end
 
 function something_expr(__module__, __source__, @nospecialize(args))
+    args = collect(Any, args)
     lnns = LineNumberNode[]
     ln = __source__
     for x in args
@@ -16,7 +17,7 @@ function something_expr(__module__, __source__, @nospecialize(args))
     end
 
     foldr(
-        zip(collect(Any, args), lnns);
+        collect(zip(args, lnns));  # `collect` for Julia 1.0
         init = :(throw(ArgumentError("all evaluated as `nothing`"))),
     ) do (x, ln), ex
         block = esc(Expr(:block, ln, x))


### PR DESCRIPTION
## Commit Message
Improve line numbers for at-something (#37)

Before (4095f1af7dfc031dcf2758fc57cb8bc9fd3677ac):

    julia> @something(nothing)
    ERROR: ArgumentError: all evaluated as `nothing`
    Stacktrace:
     [1] top-level scope at /home/takafumi/.julia/dev/Maybe/src/something.jl:22

After:

    julia> @something(nothing)
    ERROR: ArgumentError: all evaluated as `nothing`
    Stacktrace:
     [1] top-level scope at REPL[2]:1

This patch also fixes a bug in `is_advancing`.